### PR TITLE
cleanup: change the branch on the LTS branch ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 on:
   push:
     branches:
-    - 2.2.x
-  pull_request: null
+    - main
+  pull_request:
 name: ci
 jobs:
   units:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 on:
   push:
     branches:
-    - main
-  pull_request:
+    - 2.2.x
+  pull_request: null
 name: ci
 jobs:
   units:

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:23.1.0')
+implementation platform('com.google.cloud:libraries-bom:24.0.0')
 
 implementation 'com.google.cloud:google-cloud-container'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-container:2.2.0'
+implementation 'com.google.cloud:google-cloud-container:2.2.1'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-container" % "2.2.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-container" % "2.2.1"
 ```
 
 ## Authentication


### PR DESCRIPTION
### Description
- With LTS support we have a new branch created for the LTS version `2.2.x`
- Thus we need to update the workflows in the LTS branches to point to that branch

This PR follows the example of [this sample PR](https://github.com/googleapis/java-monitoring/pull/710/files). Also this PR accompanies [this other PR](https://github.com/googleapis/java-container/pull/600) that is part of setting up the LTS version!