### PR TITLE
ci: change the branch on the LTS branch ci workflow

### DIFF
--- a/.github/.OwlBot.lock.yaml
+++ b/.github/.OwlBot.lock.yaml
@@ -1,3 +1,3 @@
 docker:
   image: gcr.io/cloud-devrel-public-resources/owlbot-java:latest
-  digest: sha256:d4b2141d65566523dfd523f63c6e6899ab1281463bce182a9f600e74b0511875
+  digest: sha256:a3ac08d167454718ff057b97a1950d3cb5e16fc39fb3f355d90276285a6cac75

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 on:
   push:
     branches:
-    - main
-  pull_request:
+    - 2.2.x
+  pull_request: null
 name: ci
 jobs:
   units:

--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -38,15 +38,13 @@ function determineMavenOpts() {
       | sed -E 's/^(1\.[0-9]\.0).*$/\1/g'
   )
 
-  case $javaVersion in
-    "17")
+  if [[ $javaVersion == 17* ]]
+    then
       # MaxPermSize is no longer supported as of jdk 17
       echo -n "-Xmx1024m"
-      ;;
-    *)
+  else
       echo -n "-Xmx1024m -XX:MaxPermSize=128m"
-      ;;
-  esac
+  fi
 }
 
 export MAVEN_OPTS=$(determineMavenOpts)


### PR DESCRIPTION
### Description
- With LTS support we have a new branch created for the LTS version `2.2.x`
- Thus we need to update the workflows in the LTS branches to point to that branch

This PR follows the example of [this sample PR](https://github.com/googleapis/java-monitoring/pull/710/files). Also this PR accompanies [this other PR](https://github.com/googleapis/java-container/pull/600) that is part of setting up the LTS version!