### PR TITLE
chore: move java11-integration nightly runs moved to run in JDST

### DIFF
--- a/.kokoro/nightly/java11-integration.cfg
+++ b/.kokoro/nightly/java11-integration.cfg
@@ -13,12 +13,12 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-docs-samples-testing"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-docs-samples-testing"
 }
 
 env_vars: {

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-container'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-container:2.3.4'
+implementation 'com.google.cloud:google-cloud-container:2.3.5'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-container" % "2.3.4"
+libraryDependencies += "com.google.cloud" % "google-cloud-container" % "2.3.5"
 ```
 
 ## Authentication

--- a/owlbot.py
+++ b/owlbot.py
@@ -25,4 +25,5 @@ java.common_templates(excludes=[
     '.kokoro/presubmit/graalvm-native.cfg',
     '.kokoro/presubmit/integration.cfg',
     '.kokoro/nightly/integration.cfg',
+    '.kokoro/nightly/java11-integration.cfg'
 ])


### PR DESCRIPTION

Fixes https://github.com/googleapis/java-container/issues/673 ☕️

The `java11-integraiton` file that was added last month, and uses gcloud-devel. Moving this file to use `java-docs-sample-testing` instead. 

Like this PR https://github.com/googleapis/java-container/pull/628, which had policy issues that prevented builds from passing, and seeing this error.
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.google.cloud.container.v1.it.ITSystemTest
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.045 s <<< FAILURE! - in com.google.cloud.container.v1.it.ITSystemTest
[ERROR] com.google.cloud.container.v1.it.ITSystemTest  Time elapsed: 0.019 s  <<< ERROR!
com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: IP aliases cannot be used with a legacy network.
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:47)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:72)
```


