### PR TITLE
fix: change the default node image to cos_containerd

### DIFF
--- a/google-cloud-container/src/test/java/com/google/cloud/container/v1/it/ITSystemTest.java
+++ b/google-cloud-container/src/test/java/com/google/cloud/container/v1/it/ITSystemTest.java
@@ -148,7 +148,7 @@ public class ITSystemTest {
   public void getServerConfigTest() {
     ServerConfig config = client.getServerConfig(PROJECT_ID, ZONE);
     assertNotNull(config);
-    assertEquals("COS", config.getDefaultImageType());
+    assertEquals("COS_CONTAINERD", config.getDefaultImageType());
   }
 
   @Test


### PR DESCRIPTION
## Fixes #705 

### Description
- Integration tests were failing on the nightly builds for the repo 
- The issue was that docker was phased out as the default container runtime for GKE in `1.19`.
- Thus, it was recommended to use the node image **(cos_containerd)** which is specific to `containerd` runtime and to move away from the current node image `cos`
- In the most recent release of GKE the default node image used is `cos_containerd`
- Because of this the integration test that checks for this was failing. 
- [See release notes for information](https://cloud.google.com/kubernetes-engine/docs/release-notes#February_04_2022).

![image](https://user-images.githubusercontent.com/7249208/159737539-3e7d5e46-2c1c-4d9c-8325-45e19cd97637.png)

### Changes
- Fixed the above issue by changing the check to `COS_CONTAINERD` _(the new node image)_ from `COS`