### PR TITLE
deps: try gax 2.17.0 for Java 8 compatibility (not for merge)

### DIFF
--- a/google-cloud-container/pom.xml
+++ b/google-cloud-container/pom.xml
@@ -56,10 +56,12 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-bom</artifactId>
+        <version>2.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-container-v1</artifactId>
         <version>2.3.8-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-container-v1:current} -->


### PR DESCRIPTION
Not for merging.

Confirming GAX 2.17.0's Java 8 compatibility.