### PR TITLE
Change default var for network

### DIFF
--- a/google-cloud-container/src/test/java/com/google/cloud/container/v1/it/ITSystemTest.java
+++ b/google-cloud-container/src/test/java/com/google/cloud/container/v1/it/ITSystemTest.java
@@ -55,7 +55,7 @@ public class ITSystemTest {
           + "/zones/us-central1-a/clusters/"
           + CLUSTER_NAME;
   private static final String NODE_POOL_SEL_LINK = SELF_LINK + "/nodePools/" + NODE_POOL_NAME;
-  private static final String NETWORK = "default";
+  private static final String NETWORK = "java-container-network";
   private static final int INITIAL_NODE_COUNT = 1;
 
   @BeforeClass


### PR DESCRIPTION
Fixes #n/a☕️
Changed the network name being created
We were seeing the error where we ran into too many clusters being created with the `default` vpc network, which was also being by other java CI flows not in this repo.

