### PR TITLE
chore: Remove anthos-dpe from owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/yoshi-java is the default owner for changes in this repo
-*                       @googleapis/yoshi-java
+*                       @googleapis/yoshi-java @googleapis/yoshi-java
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/anthos-dpe is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/anthos-dpe
+# The @googleapis/yoshi-java is the default owner for changes in this repo
+*                       @googleapis/yoshi-java
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/yoshi-java is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/yoshi-java
-
+*                       @googleapis/yoshi-java
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,6 @@
     "repo": "googleapis/java-container",
     "repo_short": "java-container",
     "distribution_name": "com.google.cloud:google-cloud-container",
-    "codeowner_team": "@googleapis/yoshi-java",
     "api_id": "container.googleapis.com",
     "api_description": "is an enterprise-grade platform for containerized applications, including stateful and stateless, AI and ML, Linux and Windows, complex and simple web apps, API, and backend services. Leverage industry-first features like four-way auto-scaling and no-stress management. Optimize GPU and TPU provisioning, use integrated developer tools, and get multi-cluster support from SREs.",
     "transport": "grpc",

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,7 +9,7 @@
     "repo": "googleapis/java-container",
     "repo_short": "java-container",
     "distribution_name": "com.google.cloud:google-cloud-container",
-    "codeowner_team": "@googleapis/anthos-dpe",
+    "codeowner_team": "@googleapis/yoshi-java",
     "api_id": "container.googleapis.com",
     "api_description": "is an enterprise-grade platform for containerized applications, including stateful and stateless, AI and ML, Linux and Windows, complex and simple web apps, API, and backend services. Leverage industry-first features like four-way auto-scaling and no-stress management. Optimize GPU and TPU provisioning, use integrated developer tools, and get multi-cluster support from SREs.",
     "transport": "grpc",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.1.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.1')
 
 implementation 'com.google.cloud:google-cloud-container'
 ```


### PR DESCRIPTION
This PR removes `anthos-dpe` from the owners of this repository, as it's been fully handed over to the corresponding Yoshi team.

Related PRs:
- https://github.com/googleapis/java-container/pull/779
- https://github.com/googleapis/python-container/pull/285
- https://github.com/googleapis/nodejs-cloud-container/pull/563
- https://github.com/googleapis/google-cloud-java/pull/8271
- https://github.com/googleapis/google-cloud-node/pull/3324